### PR TITLE
Fix for error: missing CryptoJS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -169,8 +169,9 @@
          </div>
       </form>
    </div>
-   <script src="components/crypto-js/rollups/rabbit.js"></script>
-   <script src="components/crypto-js/components/sha1-min.js"></script>
+   <script src="components/crypto-js/crypto-js.js"></script>
+   <script src="components/crypto-js/rabbit.js"></script>
+   <script src="components/crypto-js/sha1-min.js"></script>
    <script src="components/underscore/underscore-min.js"></script>
    <script src="components/jquery/dist/jquery.min.js"></script>
    <script src="components/bootstrap/dist/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Contains fix for error in browser console "ReferenceError: CryptoJS is not defined".
Seems like latest crypto-js downloaded from bower has slight directory structure changes and this PR fixes this error.