### PR TITLE
Editing for QuickStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Open source, fully encrypted chat goodness. Built as an open source clone of Cha
 
 Special thanks to [tamaspiros](https://github.com/tamaspiros/advanced-chat), whose project was my main teacher of node and socket, and the spiritual predecessor to this app.
 
+## QuickStart
+
+Wondering if FreeStap is right for you?  Use the below instructions to get a local demo of FreeStep working on your machine.
+
+* Clone the repository (`git clone git@github.com:jkingsman/FreeStep.git`)
+* Install dependencies (`npm install`)
+* Start the server (`node server.js`)
+* View in browser [http://localhost:3000](http://localhost:3000)
+
 ## Installation
 
 ### Get the files

--- a/bower.json
+++ b/bower.json
@@ -2,13 +2,12 @@
   "name": "freestep",
   "version": "1.0.0",
   "dependencies": {
-    "bootstrap": "latest",
+    "bootstrap": "3.3.7",
     "jquery": "latest",
     "typeahead.js": "latest",
     "font-awesome": "latest",
     "underscore": "latest",
-    "crypto-js": "release-3.1.2-5",
-    "jasny-bootstrap": "latest"
+    "crypto-js": "3.1.9"
   },
   "directory": "components",
   "homepage": "https://github.com/jkingsman/FreeStep.git",

--- a/public/index.html
+++ b/public/index.html
@@ -169,8 +169,7 @@
          </div>
       </form>
    </div>
-   <script src="components/crypto-js/rollups/rabbit.js"></script>
-   <script src="components/crypto-js/components/sha1-min.js"></script>
+   <script src="components/crypto-js/crypto-js.js"></script>
    <script src="components/underscore/underscore-min.js"></script>
    <script src="components/jquery/dist/jquery.min.js"></script>
    <script src="components/bootstrap/dist/js/bootstrap.min.js"></script>

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -124,7 +124,7 @@ function typingTimeout() {
  *
 */
 //connection string
-var socket = io.connect("freestep.net:443");
+var socket = io.connect("127.0.0.1:3000");
 
 //vars for room data
 var myRoomID = password = name = null;

--- a/server.js
+++ b/server.js
@@ -1,21 +1,27 @@
 var express = require('express'),
+   http = require('http'),
    https = require("https"),
    fs = require('fs');
-   
+
+var app = express();
+var server;
+var enable_ssl = false;
+
 /***
  *
  * This is for HTTP redirecting to HTTPS - if you're running this as HTTP, delete below until the closing comment block
  *
  ***/ 
-var http = express();
+if (enable_ssl === true) {
+var httpapp = express();
 
 // set up a route to redirect http to https
-http.get('*',function(req,res){  
+httpapp.get('*',function(req,res){  
     res.redirect('https://freestep.net')
 })
 
 // have it listen on 80
-http.listen(80);
+httpapp.listen(80);
 
 /***
  *
@@ -32,14 +38,16 @@ var sslOptions = {
     cert: fs.readFileSync('ssl/freestep_net.crt'),
     ca: fs.readFileSync('ssl/COMODO.ca-bundle')
 };
+server = https.createServer(sslOoptions, app);
+} else {
+   server = http.createServer(app);
+}
 
-var app = express();
-var server = https.createServer(sslOptions, app);
 var io = require("socket.io").listen(server);
 
 app.configure(function () {
-   app.set('port', process.env.OPENSHIFT_NODEJS_PORT || 443);
-   app.set('ipaddr', process.env.OPENSHIFT_NODEJS_IP || "freestep.net");
+   app.set('port', process.env.OPENSHIFT_NODEJS_PORT || 3000);
+   app.set('ipaddr', process.env.OPENSHIFT_NODEJS_IP || "127.0.0.1");
    app.use(express.json());
    app.use(express.urlencoded());
    app.use(express.methodOverride());

--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ var sslOptions = {
     cert: fs.readFileSync('ssl/freestep_net.crt'),
     ca: fs.readFileSync('ssl/COMODO.ca-bundle')
 };
-server = https.createServer(sslOoptions, app);
+server = https.createServer(sslOptions, app);
 } else {
    server = http.createServer(app);
 }


### PR DESCRIPTION
Thanks for this project Jack.

I have edited the initial files to make it easier for potential users like me to analyze the project and see if it meets their needs. There were a few hang-ups that this PR resolves.

These changes were kept small intentionally (eg, no indentation for if/else) and more can come in the future. My goal was to get these changes in so others didn't hit the same issues and frustrations when evaluating the FreeStep project.

Chat works in my testing, although it's important to use the same password for both sessions. Otherwise, it will create two separate rooms. However, based on the UI, I was under the impression the password was for the user as part of a registration process and not the room. Once the room password was the same, all worked fine

- Removed: `jasny/bootstrap` is showing its age and because of its bower.json, it includes the latest v4.x Bootstrap version and breaks the Bower build step
```
bower new           version for https://github.com/twbs/bootstrap.git#>= 3.1.0
bower resolve       https://github.com/twbs/bootstrap.git#>= 3.1.0
bower checkout      bootstrap#v4.0.0-beta.2
bower EMALFORMED    Failed to read /var/folders/bm/964_ccb92kqg5j5c73g1__7h0000gn/T/ryanlelek/bower/bootstrap-10938-NggvvS/bower.json
```

- Edited. Pinned `bower.json` packages bootstrap and crypto-js to versions to prevent conflict. Future upgrade and pinning will be coming shortly

- New Defaults. SSL is off by default, with an if/else. Ports are changed to "common" Node.js project ports for familiarity and can be overridden by your environment variables `OPENSHIFT_NODEJS_*`

- Documentation: Added a quickstart section to the ReadMe